### PR TITLE
Procesar tabla Lixo_Padron y unir a las existentes

### DIFF
--- a/columnslixo.yaml
+++ b/columnslixo.yaml
@@ -1,27 +1,15 @@
-
-datasets:
-
-
-    datos_catastro:
-    
-        dir:  "C:/Users/Antón/Documents/CATASTRO/Datos Raw"
-        pattern: "Padron_Lixo.xlsx"      # o *.xlsx si lo necesitas
-        key:  ["id_parcela", "id_numcargo", "id_ctrl_1", "id_ctrl_2"]
-
-
-
-columns:                       # ② Qué columnas conservar / cómo renombrar
-    datos_catastro:
-        Desc_OT:        {as: direccion_formato1 }
-        Direccion_OT:    {as: direccion_formato2}
-        Ref_Catastral_fin: {as: id_fullref}
-        Direccion_SP_OT    {as: direccion_alt}
-        NIF_SP_OT:         {as: nif}
-        Nombre_SP:         {as: nombre_apell}
-        CP_SP_OT:          {as: postal_final}
-        Tipo_Oper_OT:      {as: analisis}
-        NOMBRE_CALL_OT:    {as: nombre_final}
-        NUMERO_OT:         {as: numero_final}
-        ESCALERA_OT:       {as: escalera_final}
-        PLANTA_OT:         {as: planta_final}
-        PUERTA_OT:         {as: puerta_final}
+columns:
+  datos_catastro:
+    Desc_OT: {as: direccion_formato1}
+    Direccion_OT: {as: direccion_formato2}
+    Ref_Catastral_Fin: {as: id_fullref}
+    Direccion_SP_OT: {as: direccion_alt}
+    NIF_SP_OT: {as: nif}
+    Nombre_SP: {as: nombre_apell}
+    CP_SP_OT: {as: postal_final}
+    Tipo_Oper_OT: {as: analisis}
+    NOMBRE_CALL_OT: {as: nombre_final}
+    NUMERO_OT: {as: numero_final}
+    ESCALERA_OT: {as: escalera_final}
+    PLANTA_OT: {as: planta_final}
+    PUERTA_OT: {as: puerta_final}

--- a/procesar_tablas.py
+++ b/procesar_tablas.py
@@ -2,8 +2,11 @@ import pandas as pd
 import yaml
 
 CONFIG_FILE = 'unionbienes-titulares.yaml'
+LIXO_CONFIG = 'columnslixo.yaml'
+
 BIEN_FILE = 'bien_inmueble.xlsx'
 TITULAR_FILE = 'titular_bien_inmueble.xlsx'
+LIXO_FILE = 'Padron_Lixo.xlsx'
 
 
 def load_config(path=CONFIG_FILE):
@@ -12,20 +15,31 @@ def load_config(path=CONFIG_FILE):
     return data['columns']
 
 
-def preparar_tabla(path, mapping):
+def preparar_tabla(path, mapping, group_field='id_parcela'):
     df = pd.read_excel(path, dtype=str)
     df = df[list(mapping.keys())]
     rename_map = {k: v['as'] for k, v in mapping.items()}
     df = df.rename(columns=rename_map)
-    df = df.sort_values('id_parcela')
-    df['miembro'] = df.groupby('id_parcela').cumcount() + 1
+
+    # Construye la referencia completa si existen los componentes necesarios
+    required = {'id_parcela', 'numero_responsables', 'id_ctr1', 'id_ctr2'}
+    if required.issubset(df.columns):
+        df['id_fullref'] = (
+            df['id_parcela'] +
+            df['numero_responsables'].astype(int).astype(str).str.zfill(4) +
+            df['id_ctr1'] +
+            df['id_ctr2']
+        )
+
+    df = df.sort_values(group_field)
+    df['miembro'] = df.groupby(group_field).cumcount() + 1
     return df
 
 
-def mostrar_grupos(df, nombre):
-    print(f"\nGrupos de {nombre} por id_parcela")
-    for i, (parcel, grupo) in enumerate(df.groupby('id_parcela')):
-        print(f"--- id_parcela: {parcel} ---")
+def mostrar_grupos(df, nombre, group_field='id_parcela'):
+    print(f"\nGrupos de {nombre} por {group_field}")
+    for i, (key, grupo) in enumerate(df.groupby(group_field)):
+        print(f"--- {group_field}: {key} ---")
         print(grupo)
         print()
         if i >= 2:  # muestra solo los tres primeros grupos
@@ -33,15 +47,20 @@ def mostrar_grupos(df, nombre):
 
 
 def main():
-    columnas = load_config()
-    bien = preparar_tabla(BIEN_FILE, columnas['bien_inmueble'])
-    titular = preparar_tabla(TITULAR_FILE, columnas['titular_bien_inmueble'])
+    columnas_union = load_config(CONFIG_FILE)
+    columnas_lixo = load_config(LIXO_CONFIG)
+
+    bien = preparar_tabla(BIEN_FILE, columnas_union['bien_inmueble'])
+    titular = preparar_tabla(TITULAR_FILE, columnas_union['titular_bien_inmueble'])
+    lixo = preparar_tabla(LIXO_FILE, columnas_lixo['datos_catastro'], group_field='id_fullref')
 
     bien.to_excel('bien_inmueble_grouped.xlsx', index=False)
     titular.to_excel('titular_bien_inmueble_grouped.xlsx', index=False)
+    lixo.to_excel('lixo_padron_grouped.xlsx', index=False)
 
     mostrar_grupos(bien, 'bien_inmueble')
     mostrar_grupos(titular, 'titular_bien_inmueble')
+    mostrar_grupos(lixo, 'lixo_padron', group_field='id_fullref')
 
 
 if __name__ == '__main__':

--- a/unir_tablas.py
+++ b/unir_tablas.py
@@ -2,12 +2,14 @@ import pandas as pd
 
 BIEN_GROUPED = 'bien_inmueble_grouped.xlsx'
 TITULAR_GROUPED = 'titular_bien_inmueble_grouped.xlsx'
+LIXO_GROUPED = 'lixo_padron_grouped.xlsx'
 
 
 def main():
     # Load grouped tables
     bien = pd.read_excel(BIEN_GROUPED, dtype=str)
     titular = pd.read_excel(TITULAR_GROUPED, dtype=str)
+    lixo = pd.read_excel(LIXO_GROUPED, dtype=str)
 
     # Merge on id_parcela and miembro so that rows align within each parcel
     merged = pd.merge(
@@ -16,6 +18,13 @@ def main():
         on=["id_parcela", "miembro"],
         how="outer",
         suffixes=("_bien", "_tit")
+    )
+
+    merged = pd.merge(
+        merged,
+        lixo,
+        on=["id_fullref", "miembro"],
+        how="left"
     )
 
     merged = merged.sort_values(["id_parcela", "miembro"])


### PR DESCRIPTION
## Summary
- agrega configuracion para la tabla de Lixo
- permite agrupar por campos arbitrarios y genera `id_fullref`
- procesa y genera la tabla `lixo_padron_grouped.xlsx`
- une los datos de Lixo con bienes y titulares usando `id_fullref`

## Testing
- `python procesar_tablas.py`
- `python unir_tablas.py`

------
https://chatgpt.com/codex/tasks/task_e_6862d6d6fb508329a8a39e20c8a86554