### PR TITLE
Add script runner

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+openpyxl
+PyYAML

--- a/run_all.py
+++ b/run_all.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Run numbered scripts sequentially after installing dependencies."""
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS = [
+    "1.columnas_tablas.py",
+    "2.parsear_direcciones.py",
+    "3.asignar_codvia.py",
+    "4.direcciones_desc.py",
+    "5.tablas_resumen.py",
+    "6.candidatos_pendientes.py",
+]
+
+REQUIREMENTS = "requirements.txt"
+SENTINEL = Path(".deps_installed")
+
+
+def install_deps():
+    """Install required packages if not already installed."""
+    if SENTINEL.exists():
+        return
+    subprocess.run([sys.executable, "-m", "pip", "install", "-r", REQUIREMENTS], check=True)
+    SENTINEL.touch()
+
+
+def run_scripts():
+    """Execute numbered scripts in order."""
+    for script in SCRIPTS:
+        subprocess.run([sys.executable, script], check=True)
+
+
+if __name__ == "__main__":
+    install_deps()
+    run_scripts()


### PR DESCRIPTION
## Summary
- add `run_all.py` that installs dependencies the first time it's run and sequentially executes numbered scripts
- specify Python dependencies in `requirements.txt`

## Testing
- `./run_all.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6876ce8500f883299a1f5d111d04b381